### PR TITLE
Fix MacOS build

### DIFF
--- a/src/strict_fstream.hpp
+++ b/src/strict_fstream.hpp
@@ -27,7 +27,7 @@ static std::string strerror()
     {
         buff = "Unknown error";
     }
-#elif (_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600) && ! _GNU_SOURCE
+#elif (_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600) && ! _GNU_SOURCE || defined(__APPLE__)
 // XSI-compliant strerror_r()
     if (strerror_r(errno, &buff[0], buff.size()) != 0)
     {


### PR DESCRIPTION
Required for building asset pipeline on MacOS. Same fix as https://github.com/mateidavid/zstr/pull/7.